### PR TITLE
Fix code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,6 +4,7 @@ import { VyukaService, InstructionService, PomuckyService, SlovnikService } from
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { Pomucka, Styl } from './types';
+import * as CryptoJS from 'crypto-js';
 
 @Component({
   selector: 'app-root',
@@ -92,7 +93,8 @@ export class AppComponent {
 
   initializeLanguage(): void {
     this.translate.addLangs(['CZ', 'EN']);
-    const selectedLanguage = localStorage.getItem("language");
+    const encryptedLanguage = localStorage.getItem("language");
+    const selectedLanguage = encryptedLanguage ? this.decrypt(encryptedLanguage) : null;
     const browserLanguage = navigator.language.substr(0, 2).toUpperCase();
     const defaultLanguage = selectedLanguage === "EN" ? 'EN' : 'CZ';
     if (selectedLanguage && (selectedLanguage === "EN" || selectedLanguage === "CZ")) {
@@ -106,7 +108,16 @@ export class AppComponent {
     }
     this.translate.setDefaultLang(this.translate.currentLang);
     this.translate.use(this.translate.currentLang);
-    localStorage.setItem("language", this.translate.currentLang);
+    localStorage.setItem("language", this.encrypt(this.translate.currentLang));
+  }
+
+  encrypt(text: string): string {
+    return CryptoJS.AES.encrypt(text, 'secret-key').toString();
+  }
+
+  decrypt(text: string): string {
+    const bytes = CryptoJS.AES.decrypt(text, 'secret-key');
+    return bytes.toString(CryptoJS.enc.Utf8);
   }
 
   initializeDarkMode(): void {


### PR DESCRIPTION
Fixes [https://github.com/Selecro/Selecro-webovky/security/code-scanning/1](https://github.com/Selecro/Selecro-webovky/security/code-scanning/1)

To fix the problem, we need to ensure that the language preference is encrypted before being stored in localStorage. We can use the `crypto-js` library to handle encryption and decryption. This will involve:
1. Importing the `crypto-js` library.
2. Creating functions to encrypt and decrypt the language preference.
3. Modifying the `initializeLanguage` method to use these functions when storing and retrieving the language preference.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
